### PR TITLE
Fix for 'org.aniszczyk.minerva 0.0.0' required but could not be found

### DIFF
--- a/org.aniszczyk.minerva-feature/feature.xml
+++ b/org.aniszczyk.minerva-feature/feature.xml
@@ -29,7 +29,14 @@
    </requires>
 
    <plugin
-         id="org.aniszczyk.minerva"
+         id="org.aniszczyk.minerva.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.aniszczyk.minerva.ui"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Hi Chris, David Carver fixed this error several days ago:

```
    [INFO] Cannot complete the request.  Generating details.
    [INFO] {org.osgi.framework.executionenvironment=OSGi/Minimum-1.0,OSGi/Minimum-1.1, osgi.ws=gtk, osgi.arch=x86, osgi.os=linux, org.eclipse.update.install.features=true, org.osgi.framework.system.packages=}
    [INFO] [Software being installed: org.aniszczyk.minerva.feature.group 1.0.0.qualifier, Missing requirement: org.aniszczyk.minerva.feature.group 1.0.0.qualifier requires 'org.aniszczyk.minerva 0.0.0' but it could not be found]
```

and I can build Minerva without any problems. Would you like to pull David's change?
