### PR TITLE
Updates for Mac and Tycho 0.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 target
-
+.DS_Store

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-feature/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__-feature/pom.xml
@@ -16,7 +16,7 @@
     <version>${version}-SNAPSHOT</version>
   </parent>
 
-  <artifactId>${artifactId}</artifactId>
+  <artifactId>${package}</artifactId>
   <packaging>eclipse-feature</packaging>
 
   <name>${projectName} Feature (Incubation)</name>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/pom.xml
@@ -11,7 +11,7 @@
 		<version>${version}-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>${artifactId}</artifactId>
+	<artifactId>${bundleId}.core.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
 
 	<name>${projectName} Core Test Plug-in</name>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.doc/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.doc/pom.xml
@@ -8,7 +8,7 @@
     <version>${version}-SNAPSHOT</version>
   </parent>
 
-  <artifactId>${artifactId}</artifactId>
+  <artifactId>${bundleId}.doc</artifactId>
   <packaging>eclipse-plugin</packaging>
 
   <name>${projectName} Documentation (Incubation)</name>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.source-feature/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.source-feature/pom.xml
@@ -15,7 +15,7 @@
     <version>${version}-SNAPSHOT</version>
   </parent>
 
-  <artifactId>${artifactId}</artifactId>
+  <artifactId>${package}.source</artifactId>
   <packaging>eclipse-feature</packaging>
 
   <name>${projectName} Sources Feature</name>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/META-INF/MANIFEST.MF
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/META-INF/MANIFEST.MF
@@ -7,9 +7,9 @@ Bundle-Version: ${version}.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.apache.log4j,
- org.eclipse.core.runtime;version="[3.4.0,4.0.0)",
- org.eclipse.core.filesystem;version="[1.1.0,2.0.0)",
- org.eclipse.core.resources;version="[3.4.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.4.0,4.0.0)",
+ org.eclipse.core.filesystem;bundle-version="[1.1.0,2.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)",
  org.hamcrest;bundle-version="[1.1.0,2.0.0)",
  ${bundleId}.ui,
@@ -33,5 +33,5 @@ Import-Package: org.eclipse.swt.widgets,
  org.junit.runner;version="[4.3.1,5.0.0)",
  org.junit.runners;version="[4.3.1,5.0.0)",
  org.osgi.framework;version="[1.4.0,2.0.0)"
-Fragment-Host: ${bundleId}.ui;bundle-version="${version}"
+Fragment-Host: ${bundleId}.ui
 Export-Package: ${bundleId}.ui.tests

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/pom.xml
@@ -8,7 +8,7 @@
     <version>${version}-SNAPSHOT</version>
   </parent>
 
-  <artifactId>${artifactId}</artifactId>
+  <artifactId>${bundleId}.ui.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
 
   <name>${projectName} UI Test Plug-in (Incubation)</name>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/pom.xml
@@ -15,7 +15,9 @@
 
   <properties>
     <local-p2-site>file:/${basedir}/../${rootArtifactId}-repository/target/repository</local-p2-site>
-    <ui.test.vmargs>-Xmx512m -XX:MaxPermSize=256m</ui.test.vmargs>
+    <ui.test.vmargs.all>-Xmx512m -XX:MaxPermSize=256m</ui.test.vmargs.all>
+    <ui.test.vmargs.mac>-XstartOnFirstThread</ui.test.vmargs.mac>
+    <ui.test.vmargs>${ui.test.vmargs.all}</ui.test.vmargs>
   </properties>
 
   <repositories>
@@ -38,6 +40,17 @@
         <maven.test.skip>true</maven.test.skip>
       </properties>
     </profile>
+    <profile>
+      <id>mac-customization</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <properties>
+        <ui.test.vmargs>${ui.test.vmargs.all} ${ui.test.vmargs.mac}</ui.test.vmargs>
+      </properties>
+    </profile>
   </profiles>
 
   <build>
@@ -49,6 +62,7 @@
         <configuration>
           <useUIHarness>true</useUIHarness>
           <useUIThread>true</useUIThread>
+          <argLine>${ui.test.vmargs}</argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,12 +26,12 @@
   </licenses>
 
   <properties>
-    <tycho-version>0.12.0</tycho-version>
+    <tycho-version>0.13.0</tycho-version>
     <platform-version-name>helios</platform-version-name>
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>
     <swtbot-site>http://download.eclipse.org/technology/swtbot/${platform-version-name}/dev-build/update-site</swtbot-site>
-    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/S20110124210048/repository</orbit-site>
+    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository</orbit-site>
   </properties>
 
   <repositories>

--- a/org.aniszczyk.minerva-feature/feature.xml
+++ b/org.aniszczyk.minerva-feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.aniszczyk.minerva"
+      id="org.aniszczyk.minerva-feature"
       label="%featureName"
       version="1.0.0.qualifier"
       provider-name="%providerName">

--- a/org.aniszczyk.minerva-repository/category.xml
+++ b/org.aniszczyk.minerva-repository/category.xml
@@ -3,10 +3,10 @@
    <description url="http://github.com/caniszczyk/minerva">
 	Minerva
    </description>
-   <feature url="features/org.aniszczyk.minerva_0.0.0.qualifier.jar" id="org.aniszczyk.minerva" version="0.0.0" patch="false">
+   <feature url="features/org.aniszczyk.minerva_0.0.0.qualifier.jar" id="org.aniszczyk.minerva-feature" version="0.0.0" patch="false">
       <category name="Minerva Plug-in"/>
    </feature>
-   <feature url="features/org.aniszczyk.minerva.sources_0.0.0.qualifier.jar" id="org.aniszczyk.minerva.source" version="0.0.0" patch="false">
+   <feature url="features/org.aniszczyk.minerva.sources_0.0.0.qualifier.jar" id="org.aniszczyk.minerva.source-feature" version="0.0.0" patch="false">
       <category name="Minerva Plug-in"/>
    </feature>
    <category-def name="Minerva Example" label="Minerva Example">

--- a/org.aniszczyk.minerva.source-feature/feature.xml
+++ b/org.aniszczyk.minerva.source-feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.aniszczyk.minerva.source"
+      id="org.aniszczyk.minerva.source-feature"
       label="%featureName"
       version="1.0.0.qualifier"
       provider-name="%providerName"

--- a/org.aniszczyk.minerva.tests.ui/META-INF/MANIFEST.MF
+++ b/org.aniszczyk.minerva.tests.ui/META-INF/MANIFEST.MF
@@ -7,9 +7,9 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.apache.log4j,
- org.eclipse.core.runtime;version="[3.4.0,4.0.0)",
- org.eclipse.core.filesystem;version="[1.1.0,2.0.0)",
- org.eclipse.core.resources;version="[3.4.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.4.0,4.0.0)",
+ org.eclipse.core.filesystem;bundle-version="[1.1.0,2.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.4.0,4.0.0)",
  org.hamcrest;bundle-version="[1.1.0,2.0.0)",
  org.aniszczyk.minerva.ui,
@@ -33,5 +33,5 @@ Import-Package: org.eclipse.swt.widgets,
  org.junit.runner;version="[4.3.1,5.0.0)",
  org.junit.runners;version="[4.3.1,5.0.0)",
  org.osgi.framework;version="[1.4.0,2.0.0)"
-Fragment-Host: org.aniszczyk.minerva.ui;bundle-version="1.0.0"
+Fragment-Host: org.aniszczyk.minerva.ui
 Export-Package: org.aniszczyk.minerva.ui.tests

--- a/org.aniszczyk.minerva.tests.ui/pom.xml
+++ b/org.aniszczyk.minerva.tests.ui/pom.xml
@@ -25,7 +25,7 @@
   <name>Minerva UI Test Plug-in (Incubation)</name>
 
   <properties>
-    <local-p2-site>file:/${basedir}/../org.aniszczyk.minerva-updatesite/target/site</local-p2-site>
+    <local-p2-site>file:/${basedir}/../org.aniszczyk.minerva-repository/target/repository</local-p2-site>
     <ui.test.vmargs.all>-Xmx512m -XX:MaxPermSize=256m</ui.test.vmargs.all>
     <ui.test.vmargs.mac>-XstartOnFirstThread</ui.test.vmargs.mac>
     <ui.test.vmargs>${ui.test.vmargs.all}</ui.test.vmargs>
@@ -84,17 +84,17 @@
               <artifactId>org.eclipse.pde.feature.group</artifactId>
               <version>${platform-version}</version>
             </dependency>
-            <dependency> -->
-              <type>p2-installable-unit</type>
-              <artifactId>org.aniszczyk.minerva.feature.group</artifactId>
-              <version>1.0.0</version>
+            <dependency>
+              <type>eclipse-feature</type>
+              <artifactId>org.aniszczyk.minerva-feature</artifactId>
+              <version>0.0.0</version>
             </dependency>
             <dependency>
               <type>p2-installable-unit</type>
               <artifactId>org.eclipse.cvs.feature.group</artifactId>
               <version>[1.1.2,2.0.0)</version>
             </dependency>
-           </dependencies>
+          </dependencies>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -39,12 +39,12 @@
   </licenses>
 
   <properties>
-    <tycho-version>0.12.0</tycho-version>
+    <tycho-version>0.13.0</tycho-version>
     <platform-version-name>helios</platform-version-name>
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>
     <swtbot-site>http://download.eclipse.org/technology/swtbot/${platform-version-name}/dev-build/update-site</swtbot-site>
-    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/S20110124210048/repository</orbit-site>
+    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository/</orbit-site>
   </properties>
 
 


### PR DESCRIPTION
1. Use vmargs in archetype tests, add Mac customization (vmargs were unused in general, and are required on Mac)
2. Build with Tycho 0.13.0: Overall, Tycho 0.13.0 is stricter than the previous version. In particular artifact ids in poms have to match the feature and bundle ids. This required changes in a few places. For details, see the Tycho release notes at: http://wiki.eclipse.org/Tycho/Release_Notes/0.13
