### PR TITLE
Archetype - use of bundle attributes (manifest & properties)

### DIFF
--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/META-INF/MANIFEST.MF
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Minerva
-Bundle-Vendor: aniszczyk.org
+Bundle-Name: ${projectName} Core Test
+Bundle-Vendor: ${providerName}
 Bundle-SymbolicName: ${bundleId}.core.tests
 Bundle-Version: ${version}.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.4.0,4.0.0)",

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/META-INF/MANIFEST.MF
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: ${bundleId}.core
+Bundle-Vendor: %Bundle-Vendor

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/OSGI-INF/l10n/bundle.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/OSGI-INF/l10n/bundle.properties
@@ -1,4 +1,6 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
+${symbol_pound} Properties file for ${package}
 Bundle-Name = ${projectName} Core
+Bundle-Vendor = ${providerName}

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.doc/plugin.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.doc/plugin.properties
@@ -8,5 +8,5 @@ ${symbol_pound} are made available under the terms of the Eclipse Public License
 ${symbol_pound} which accompanies this distribution, and is available at
 ${symbol_pound} http://www.eclipse.org/legal/epl-v10.html
 ${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}${symbol_pound}
-Bundle-Vendor = Minerva
-Bundle-Name = Minerva Documentation (Incubation)
+Bundle-Vendor = ${providerName}
+Bundle-Name = ${projectName} Documentation (Incubation)

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/META-INF/MANIFEST.MF
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Minerva UI Tests
-Bundle-Vendor: aniszczyk.org
+Bundle-Name: ${projectName} UI Test
+Bundle-Vendor: ${providerName}
 Bundle-SymbolicName: ${bundleId}.ui.tests
 Bundle-Version: ${version}.qualifier
 Bundle-ActivationPolicy: lazy

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/META-INF/MANIFEST.MF
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: ${bundleId}.ui,
  ${bundleId}.ui.views
+Bundle-Vendor: %Bundle-Vendor

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/OSGI-INF/l10n/bundle.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/OSGI-INF/l10n/bundle.properties
@@ -4,4 +4,5 @@
 ${symbol_pound}Properties file for ${package}
 category.name = Sample Category
 view.name = Sample View
-Bundle-Name = Minerva UI
+Bundle-Name = ${projectName} UI
+Bundle-Vendor = ${providerName}


### PR DESCRIPTION
With this pull request, we define/use two attributes: bundle-vendor and bundle_name
