### PR TITLE
Build with Tycho 0.14.1

### DIFF
--- a/minerva-eclipse-project-archetype/pom.xml
+++ b/minerva-eclipse-project-archetype/pom.xml
@@ -41,6 +41,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
+        <version>1.5</version>
         <executions>
           <execution>
             <id>generate-projects</id>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/pom.xml
@@ -19,8 +19,8 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.sonatype.tycho</groupId>
-				<artifactId>maven-osgi-test-plugin</artifactId>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
 					<excludes>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/build.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/build.properties
@@ -3,8 +3,7 @@
 #set( $symbol_escape = '\' )
 source.. = src/
 output.. = bin/
-bin.includes = plugin.xml,${symbol_escape}
-               META-INF/,${symbol_escape}
+bin.includes = META-INF/,${symbol_escape}
                .,${symbol_escape}
-               icons/,${symbol_escape}
+               OSGI-INF/,${symbol_escape}
                OSGI-INF/l10n/bundle.properties

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.doc/build.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.doc/build.properties
@@ -6,8 +6,4 @@ bin.includes = META-INF/,${symbol_escape}
                about.html,${symbol_escape}
                help/,${symbol_escape}
                plugin.properties,${symbol_escape}
-               plugin.xml,${symbol_escape}
-               images/,${symbol_escape}
-               intro/,${symbol_escape}
-               cheatsheets/,${symbol_escape}
-               contexts.xml
+               plugin.xml

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/pom.xml
@@ -14,19 +14,10 @@
   <name>${projectName} UI Test Plug-in (Incubation)</name>
 
   <properties>
-    <local-p2-site>file:/${basedir}/../${rootArtifactId}-repository/target/repository</local-p2-site>
     <ui.test.vmargs.all>-Xmx512m -XX:MaxPermSize=256m</ui.test.vmargs.all>
     <ui.test.vmargs.mac>-XstartOnFirstThread</ui.test.vmargs.mac>
     <ui.test.vmargs>${ui.test.vmargs.all}</ui.test.vmargs>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>local-p2</id>
-      <layout>p2</layout>
-      <url>${local-p2-site}</url>
-    </repository>
-  </repositories>
 
   <profiles>
     <profile>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/build.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/build.properties
@@ -7,4 +7,5 @@ bin.includes = plugin.xml,${symbol_escape}
                META-INF/,${symbol_escape}
                .,${symbol_escape}
                icons/,${symbol_escape}
+               OSGI-INF/,${symbol_escape}
                OSGI-INF/l10n/bundle.properties

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
   </licenses>
 
   <properties>
-    <tycho-version>0.13.0</tycho-version>
+    <tycho-version>0.14.1</tycho-version>
     <platform-version-name>helios</platform-version-name>
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>

--- a/org.aniszczyk.minerva.core/build.properties
+++ b/org.aniszczyk.minerva.core/build.properties
@@ -1,7 +1,6 @@
 source.. = src/
 output.. = bin/
-bin.includes = plugin.xml,\
-               META-INF/,\
+bin.includes = META-INF/,\
                .,\
-               icons/,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/l10n/bundle.properties,\
+               OSGI-INF/

--- a/org.aniszczyk.minerva.doc/build.properties
+++ b/org.aniszczyk.minerva.doc/build.properties
@@ -4,7 +4,4 @@ bin.includes = META-INF/,\
                help/,\
                plugin.properties,\
                plugin.xml,\
-               images/,\
-               intro/,\
-               cheatsheets/,\
-               contexts.xml
+               images/

--- a/org.aniszczyk.minerva.tests.ui/pom.xml
+++ b/org.aniszczyk.minerva.tests.ui/pom.xml
@@ -25,19 +25,10 @@
   <name>Minerva UI Test Plug-in (Incubation)</name>
 
   <properties>
-    <local-p2-site>file:/${basedir}/../org.aniszczyk.minerva-repository/target/repository</local-p2-site>
     <ui.test.vmargs.all>-Xmx512m -XX:MaxPermSize=256m</ui.test.vmargs.all>
     <ui.test.vmargs.mac>-XstartOnFirstThread</ui.test.vmargs.mac>
     <ui.test.vmargs>${ui.test.vmargs.all}</ui.test.vmargs>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>local-p2</id>
-      <layout>p2</layout>
-      <url>${local-p2-site}</url>
-    </repository>
-  </repositories>
 
   <profiles>
     <profile>

--- a/org.aniszczyk.minerva.ui/build.properties
+++ b/org.aniszczyk.minerva.ui/build.properties
@@ -4,4 +4,5 @@ bin.includes = plugin.xml,\
                META-INF/,\
                .,\
                icons/,\
-               OSGI-INF/l10n/bundle.properties
+               OSGI-INF/l10n/bundle.properties,\
+               OSGI-INF/

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </licenses>
 
   <properties>
-    <tycho-version>0.13.0</tycho-version>
+    <tycho-version>0.14.1</tycho-version>
     <platform-version-name>helios</platform-version-name>
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>


### PR DESCRIPTION
Required some cleanup in build.properties files due to stricter
checks by Tycho 0.14, and minor tweaks in poms. For details, see
the Tycho release notes at:

http://wiki.eclipse.org/Tycho/Release_Notes/0.14
