### PR TITLE
Build with Tycho 0.16.0 & Juno

### DIFF
--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -192,9 +192,23 @@
       <properties>
         <eclipse-site>http://download.eclipse.org/releases/indigo</eclipse-site>
         <platform-version>[3.7,3.8)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/indigo/dev-build/update-site</swtbot-site>
+        <swtbot-site>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
+	<profile>
+		<id>platform-juno</id>
+		<activation>
+			<property>
+				<name>platform-version-name</name>
+				<value>juno</value>
+			</property>
+		</activation>
+		<properties>
+			<eclipse-site>http://download.eclipse.org/releases/juno</eclipse-site>
+			<platform-version>[3.8,3.9)</platform-version>
+			<swtbot-site>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site</swtbot-site>
+		</properties>
+	</profile>
 	<profile>
 		<id>checkstyle</id>
 		<activation>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
   </licenses>
 
   <properties>
-    <tycho-version>0.14.1</tycho-version>
+    <tycho-version>0.16.0</tycho-version>
     <platform-version-name>helios</platform-version-name>
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -31,7 +31,7 @@
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>
     <swtbot-site>http://download.eclipse.org/technology/swtbot/${platform-version-name}/dev-build/update-site</swtbot-site>
-    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository</orbit-site>
+    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository</orbit-site>
   </properties>
 
   <repositories>
@@ -117,7 +117,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.4.1</version>
+          <version>2.6</version>
           <configuration>
             <encoding>ISO-8859-1</encoding>
           </configuration>
@@ -125,12 +125,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.3</version>
+          <version>1.7</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>2.5.2</version>
           <configuration>
             <findbugsXmlOutput>true</findbugsXmlOutput>
             <failOnError>false</failOnError>
@@ -146,7 +146,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.7.1</version>
           <configuration>
             <sourceEncoding>utf-8</sourceEncoding>
             <minimumTokens>100</minimumTokens>
@@ -218,7 +218,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.6</version>
+					<version>2.9.1</version>
 					<executions>
 						<execution>
 							<id>check my sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>
     <swtbot-site>http://download.eclipse.org/technology/swtbot/${platform-version-name}/dev-build/update-site</swtbot-site>
-    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20110523182458/repository/</orbit-site>
+    <orbit-site>http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</orbit-site>
   </properties>
 
 
@@ -131,7 +131,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.4.1</version>
+          <version>2.6</version>
           <configuration>
             <encoding>ISO-8859-1</encoding>
           </configuration>
@@ -139,12 +139,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.3</version>
+          <version>1.7</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>2.5.2</version>
           <configuration>
             <findbugsXmlOutput>true</findbugsXmlOutput>
             <failOnError>false</failOnError>
@@ -160,7 +160,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.7.1</version>
           <configuration>
             <sourceEncoding>utf-8</sourceEncoding>
             <minimumTokens>100</minimumTokens>
@@ -233,7 +233,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.6</version>
+					<version>2.9.1</version>
 					<executions>
 						<execution>
 							<id>check my sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   </licenses>
 
   <properties>
-    <tycho-version>0.14.1</tycho-version>
+    <tycho-version>0.16.0</tycho-version>
     <platform-version-name>helios</platform-version-name>
     <eclipse-site>http://download.eclipse.org/releases/${platform-version-name}</eclipse-site>
     <wikitext-site>http://download.eclipse.org/tools/mylyn/update/weekly</wikitext-site>

--- a/pom.xml
+++ b/pom.xml
@@ -206,9 +206,23 @@
       <properties>
         <eclipse-site>http://download.eclipse.org/releases/indigo</eclipse-site>
         <platform-version>[3.7,3.8)</platform-version>
-        <swtbot-site>http://download.eclipse.org/technology/swtbot/indigo/dev-build/update-site</swtbot-site>
+        <swtbot-site>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site</swtbot-site>
       </properties>
     </profile>
+	<profile>
+		<id>platform-juno</id>
+		<activation>
+			<property>
+				<name>platform-version-name</name>
+				<value>juno</value>
+			</property>
+		</activation>
+		<properties>
+			<eclipse-site>http://download.eclipse.org/releases/juno</eclipse-site>
+			<platform-version>[3.8,3.9)</platform-version>
+			<swtbot-site>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site</swtbot-site>
+		</properties>
+	</profile>
 	<profile>
 		<id>checkstyle</id>
 		<activation>


### PR DESCRIPTION
An update for Juno Eclipse and Tycho 0.16 :
- this patch includes a profile for Juno (the Helios profile is the default profile),
- the transition to Tycho 0.16 requires no modification of the archetype,
- the external libraries and plugins have been updated with the latest release versions.
