### PR TITLE
M2eclipse compliance

### DIFF
--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/.classpath
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/.classpath
@@ -6,5 +6,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/build.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core.tests/build.properties
@@ -2,6 +2,6 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 source.. = src/
-output.. = bin/
+output.. = target/classes/
 bin.includes = META-INF/,${symbol_escape}
                .

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/.classpath
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/.classpath
@@ -6,5 +6,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/build.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.core/build.properties
@@ -2,7 +2,7 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 source.. = src/
-output.. = bin/
+output.. = target/classes/
 bin.includes = META-INF/,${symbol_escape}
                .,${symbol_escape}
                OSGI-INF/,${symbol_escape}

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/.classpath
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/.classpath
@@ -6,5 +6,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/build.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui.tests/build.properties
@@ -2,6 +2,6 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 source.. = src/
-output.. = bin/
+output.. = target/classes/
 bin.includes = META-INF/,${symbol_escape}
 	       .

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/.classpath
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/.classpath
@@ -6,5 +6,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/build.properties
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/__rootArtifactId__.ui/build.properties
@@ -2,7 +2,7 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 source.. = src/
-output.. = bin/
+output.. = target/classes/
 bin.includes = plugin.xml,${symbol_escape}
                META-INF/,${symbol_escape}
                .,${symbol_escape}

--- a/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/minerva-eclipse-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -97,17 +97,13 @@
             <encoding>UTF-8</encoding>
           </configuration>
         </plugin>
-        <plugin>
-          <!-- TODO remove workaround when
-             https://issues.sonatype.org/browse/TYCHO-473
-             is fixed -->
+        <plugin>          
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-source-plugin</artifactId>
           <version>${tycho-version}</version>
           <executions>
             <execution>
-              <id>attach-source</id>
-              <phase>process-classes</phase>
+              <id>attach-source</id>              
               <goals>
                 <goal>plugin-source</goal>
               </goals>


### PR DESCRIPTION
With this patch the generated projects could be build with m2eclipse 1.x
- an old workaround for Tycho was no longer compatible with the latest releases of m2eclipse
- now, the output folders are compliant with the Maven/M2E requirements

Note: the execution of maven-ant-plugin is not supported by m2eclipse. This patch does not provide any workaround for the generation of the documentation with this Maven plugin.... However, the Eclipse developer may force the execution of the plugin with some minor change into the pom (m2eclipse 1.2 provides also a workaround that does not require rewriting the pom).
